### PR TITLE
Build:RNCamera iOS specific rewiring | Capture path changes for both Android and iOS

### DIFF
--- a/ios/RetailAttendanceMonitor.xcodeproj/project.pbxproj
+++ b/ios/RetailAttendanceMonitor.xcodeproj/project.pbxproj
@@ -552,6 +552,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		3A65EF66203EA5B500D8AD07 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				DB954C819A744DA0BF55598F /* libRNFIRMessaging.a */,
+				B22AC9C408BC429B99FADDA2 /* libRCTCamera.a */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		3A9B81CE1ED5711E00C7D8DB /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -658,6 +667,7 @@
 				83CBBA001A601CBA00E9B192 /* Products */,
 				710736D6A2905D57E20F5BEC /* Pods */,
 				D5D3ABE19E309AD40909B1C6 /* Frameworks */,
+				3A65EF66203EA5B500D8AD07 /* Recovered References */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "axios": "^0.16.1",
     "firebase": "^3.9.0",
     "react": "^16.0.0-alpha.6",
-    "react-native": "0.43.4",
+    "react-native": "0.44.0",
     "react-native-android-location-services-dialog-box": "^1.2.1",
     "react-native-camera": "git+https://github.com/lwansbrough/react-native-camera.git",
     "react-native-config": "^0.4.2",

--- a/src/components/core/AttendanceCam.js
+++ b/src/components/core/AttendanceCam.js
@@ -4,7 +4,7 @@
  * @Project: Retailstore-Attendance-Monitor
  * @Filename: AttendanceCam.js
  * @Last modified by:   harsha
- * @Last modified time: 2017-08-22T15:31:32+05:30
+ * @Last modified time: 2018-02-22T12:56:45+05:30
  * @License: Apache License v2.0
  */
 
@@ -17,7 +17,7 @@ import {
   TouchableOpacity
 } from 'react-native';
 /* importing required modules from the react-native-camera Component */
-import Camera, { constants } from 'react-native-camera';
+import { RNCamera } from 'react-native-camera';
 /**/
 import * as firebase from 'firebase';
 /* Component for implementing reverse-Geocoding */
@@ -89,9 +89,9 @@ This is bound to the onPress call on the render metod of the AttendanceCam compo
     /*camera.capture is a react-native-camera module based trigger which takes in metadata from the
      options variable above and returns principally the path(saved file path) of the generated image
        */
-    this.camera.capture({ metadata: options })
+    this.camera.takePictureAsync({ metadata: options })
     .then((data) => {
-      const SavedImage = data.path;
+      const SavedImage = data.uri;
       if (SavedImage) {
         /*Here we get the unique id that firebase generates for each use using firebase.auth()  */
         const { currentUser } = firebase.auth();
@@ -165,18 +165,15 @@ This is bound to the onPress call on the render metod of the AttendanceCam compo
       <View style={styles.main}>
         {/*Camera module imported from  react-native-camera with all the necessary
          accessibility options */}
-        <Camera
+        <RNCamera
           ref={(cam) => {
             this.camera = cam;
           }}
           style={styles.camera}
-          aspect={constants.Aspect.fill}
           type={this.state.cameraType}
           mirrorImage={this.state.mirrorMode}
           playSoundOnCapture={false}
-          captureTarget={constants.CaptureTarget.disk}
-        >
-        </Camera>
+        />
         {/*captureSwitch() used to switch between views based on user interaction*/}
         {this.captureSwitch()}
       </View>


### PR DESCRIPTION
- Bumped up react-native version to work with the corresponding bumped up react 16 build
- propType accessibility changes from this version
- Rewiring of the RNCamera module for iOS devices
-  RNCamera capture path changed for iOS and Android